### PR TITLE
Fix potential nil access spotted by nilaway

### DIFF
--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -126,7 +126,7 @@ func (m *mirror) Mirror(ctx context.Context) error {
 		// If only the last n images
 		sort.Sort(semver.Collection(semverTags))
 
-		if image.Match.Last != nil {
+		if image.Match.Last != nil && semverTags != nil {
 			for _, v := range semverTags[len(semverTags)-int(*image.Match.Last):] {
 				if slices.Contains(tags, v.String()) {
 					src := image.Source + ":" + v.String()


### PR DESCRIPTION
[nilaway](https://github.com/uber-go/nilaway) found this:

```bash
nilaway ./...
/home/stefan/dev/github.com/metal-stack/oci-mirror/pkg/mirror/mirror.go:130:22: error: Potential nil panic detected. Observed nil flow from source to dereference point: 
        -> mirror/mirror.go:130:22: unassigned variable `semverTags` sliced into
```
